### PR TITLE
Add secondary friction coefficient parameter (#1424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Added joint velocity limit constraint support: [#1407](https://github.com/dartsim/dart/pull/1407)
   * Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
   * Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
+  * Added secondary friction coefficient parameter: [#1424](https://github.com/dartsim/dart/pull/1424)
 
 * GUI
 

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -140,6 +140,10 @@ protected:
 
   static double computeFrictionCoefficient(
       const dynamics::ShapeNode* shapeNode);
+  static double computePrimaryFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
+  static double computeSecondaryFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
   static double computeRestitutionCoefficient(
       const dynamics::ShapeNode* shapeNode);
 
@@ -173,8 +177,11 @@ private:
   /// First frictional direction
   Eigen::Vector3d mFirstFrictionalDirection;
 
-  /// Coefficient of Friction
-  double mFrictionCoeff;
+  /// Primary Coefficient of Friction
+  double mPrimaryFrictionCoeff;
+
+  /// Primary Coefficient of Friction
+  double mSecondaryFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -55,7 +55,21 @@ CollisionAspectProperties::CollisionAspectProperties(const bool collidable)
 //==============================================================================
 DynamicsAspectProperties::DynamicsAspectProperties(
     const double frictionCoeff, const double restitutionCoeff)
-  : mFrictionCoeff(frictionCoeff), mRestitutionCoeff(restitutionCoeff)
+  : mFrictionCoeff(frictionCoeff),
+    mRestitutionCoeff(restitutionCoeff),
+    mSecondaryFrictionCoeff(frictionCoeff)
+{
+  // Do nothing
+}
+
+//==============================================================================
+DynamicsAspectProperties::DynamicsAspectProperties(
+    const double primaryFrictionCoeff,
+    const double secondaryFrictionCoeff,
+    const double restitutionCoeff)
+  : mFrictionCoeff(primaryFrictionCoeff),
+    mRestitutionCoeff(restitutionCoeff),
+    mSecondaryFrictionCoeff(secondaryFrictionCoeff)
 {
   // Do nothing
 }
@@ -171,6 +185,29 @@ DynamicsAspect::DynamicsAspect(const PropertiesData& properties)
   : Base(properties)
 {
   // Do nothing
+}
+
+void DynamicsAspect::setFrictionCoeff(const double& value)
+{
+  mProperties.mFrictionCoeff = value;
+  mProperties.mSecondaryFrictionCoeff = value;
+}
+
+double DynamicsAspect::getFrictionCoeff() const
+{
+  return 0.5 * (
+      mProperties.mFrictionCoeff +
+      mProperties.mSecondaryFrictionCoeff);
+}
+
+void DynamicsAspect::setPrimaryFrictionCoeff(const double& value)
+{
+  mProperties.mFrictionCoeff = value;
+}
+
+const double& DynamicsAspect::getPrimaryFrictionCoeff() const
+{
+  return mProperties.mFrictionCoeff;
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -143,9 +143,18 @@ public:
 
   DynamicsAspect(const PropertiesData& properties = PropertiesData());
 
-  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, FrictionCoeff)
-  // void setFrictionCoeff(const double& value);
-  // const double& getFrictionCoeff() const;
+  /// Set both primary and secondary friction coefficients to the same value.
+  void setFrictionCoeff(const double& value);
+  /// Get average of primary and secondary friction coefficients.
+  double getFrictionCoeff() const;
+
+  // DART_COMMON_SET_GET_ASPECT_PROPERTY(double, PrimaryFrictionCoeff)
+  void setPrimaryFrictionCoeff(const double& value);
+  const double& getPrimaryFrictionCoeff() const;
+
+  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, SecondaryFrictionCoeff)
+  // void setSecondaryFrictionCoeff(const double& value);
+  // const double& getSecondaryFrictionCoeff() const;
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)
   // void setRestitutionCoeff(const double& value);
   // const double& getRestitutionCoeff() const;

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -88,15 +88,24 @@ struct CollisionAspectProperties
 
 struct DynamicsAspectProperties
 {
-  /// Coefficient of friction
+  /// Primary coefficient of friction
   double mFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;
 
-  /// Constructor
+  /// Secondary coefficient of friction
+  double mSecondaryFrictionCoeff;
+
+  /// Constructors
+  /// The frictionCoeff argument will be used for both primary and secondary friction
   DynamicsAspectProperties(
       const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0);
+
+  DynamicsAspectProperties(
+      const double primaryFrictionCoeff,
+      const double secondaryFrictionCoeff,
+      const double restitutionCoeff);
 
   /// Destructor
   virtual ~DynamicsAspectProperties() = default;

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -80,15 +80,46 @@ TEST(Friction, FrictionPerShapeNode)
   skeleton1->setName("Skeleton2");
 
   auto body1 = skeleton1->getRootBodyNode();
-  EXPECT_DOUBLE_EQ(
-      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   auto body2 = skeleton2->getRootBodyNode();
-  EXPECT_DOUBLE_EQ(
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  // test setting primary friction
+  body2->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.5);
+  EXPECT_DOUBLE_EQ(0.75,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.5,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  // test setting secondary friction
+  body2->getShapeNode(0)->getDynamicsAspect()->setSecondaryFrictionCoeff(0.25);
+  EXPECT_DOUBLE_EQ(0.375,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.5,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.25,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  // set all friction coeffs to 0.0
   body2->getShapeNode(0)->getDynamicsAspect()->setFrictionCoeff(0.0);
-  EXPECT_DOUBLE_EQ(
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 0.0);
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   // Create a world and add the rigid body
   auto world = simulation::World::create();


### PR DESCRIPTION
* ContactConstraint: use secondary friction coeff

* ShapeFrame DynamicsAspect: add secondary friction

* ShapeFrame: set both coeffs with setFrictionCoeff

Rename mFrictionCoeff to mPrimaryFrictionCoeff
and replace auto-generated (set|get)FrictionCoeff
with custom functions that set both coefficients
and return the average of the coefficients.

* test_Friction: reduce expectation line length

* test_Friction: coverage for new functions

* ShapeFrame DynamicsAspect: override constructor

* ContactConstraint: add computePrimaryFrictionCoefficient

* ContactConstraint: use primary in variable names

* Update dart/dynamics/ShapeFrame.hpp

Co-Authored-By: Jeongseok Lee <jslee02@users.noreply.github.com>

* restore property name, add explicit get/set

* Update changelog for #1424

[Remove this line and describe this pull request. Link to relevant GitHub issues, if any.]

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
